### PR TITLE
DEV-7985_Update-GUI-to-handle-PMA

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2136,6 +2136,7 @@
 
   "device_none": "None",
   "device_paneda-6ch-dab-enc": "Paneda 6 channel DAB encoder",
+  "device_paneda-8ch-dab-enc": "Paneda 8 channel DAB encoder",
   "device_paneda-16ch-dab-enc": "Paneda 16 channel DAB encoder",
 
   "msc_item_remark_audio-source-incompatible-transport": "Audio source incompatible transport",


### PR DESCRIPTION
Adding support for Paneda's new 8ch PMA sound device.